### PR TITLE
Connect frontend to backend API

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -1,9 +1,17 @@
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5008/api';
 
 export async function api(path: string, options: RequestInit = {}) {
+  const token = localStorage.getItem('token');
   const res = await fetch(`${API_URL}${path}`, {
-    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(options.headers || {}),
+    },
     ...options,
   });
+  if (!res.ok) {
+    throw new Error((await res.json()).message || 'Request failed');
+  }
   return res.json();
 }

--- a/client/src/pages/Chat.tsx
+++ b/client/src/pages/Chat.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { api } from '../api';
 
 type Message = { sender: 'user' | 'bot'; text: string };
 
@@ -6,11 +7,22 @@ export default function Chat() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
 
-  const handleSend = (e: React.FormEvent) => {
+  const handleSend = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!input) return;
-    setMessages([...messages, { sender: 'user', text: input }, { sender: 'bot', text: "I'm here for you." }]);
+    const userMessage = input;
+    setMessages([...messages, { sender: 'user', text: userMessage }]);
     setInput('');
+    try {
+      const data = await api('/chat', {
+        method: 'POST',
+        body: JSON.stringify({ message: userMessage }),
+      });
+      setMessages(prev => [...prev, { sender: 'bot', text: data.response }]);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Error sending message';
+      setMessages(prev => [...prev, { sender: 'bot', text: msg }]);
+    }
   };
 
   return (

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,18 +1,34 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { api } from '../api';
 
 export default function Dashboard() {
   const [mood, setMood] = useState('');
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
 
-  const handleMood = (e: React.FormEvent) => {
+  const handleMood = async (e: React.FormEvent) => {
     e.preventDefault();
-    // TODO: call API
-    setMood('');
+    try {
+      await api('/mood', {
+        method: 'POST',
+        body: JSON.stringify({ mood }),
+      });
+      setMood('');
+      setSuccess('Mood logged!');
+      setError('');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to log mood';
+      setError(msg);
+      setSuccess('');
+    }
   };
 
   return (
     <div className="max-w-4xl mx-auto px-4">
       <h2 className="text-2xl font-semibold mb-6">Dashboard</h2>
+      {error && <p className="text-red-600 text-sm mb-2">{error}</p>}
+      {success && <p className="text-green-600 text-sm mb-2">{success}</p>}
       <form onSubmit={handleMood} className="flex gap-2 mb-6">
         <input
           className="border rounded p-2 flex-1"

--- a/client/src/pages/Journal.tsx
+++ b/client/src/pages/Journal.tsx
@@ -1,17 +1,29 @@
 import { useState } from 'react';
+import { api } from '../api';
 
 export default function Journal() {
   const [text, setText] = useState('');
+  const [message, setMessage] = useState('');
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // TODO: call API
-    setText('');
+    try {
+      await api('/journal', {
+        method: 'POST',
+        body: JSON.stringify({ text }),
+      });
+      setText('');
+      setMessage('Entry saved!');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to save entry';
+      setMessage(msg);
+    }
   };
 
   return (
     <div className="max-w-2xl mx-auto px-4">
       <h2 className="text-2xl font-semibold mb-4">Journal Entry</h2>
+      {message && <p className="text-sm mb-2">{message}</p>}
       <form onSubmit={handleSubmit} className="flex flex-col gap-3">
         <textarea
           className="border rounded p-2"

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,15 +1,27 @@
 import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
+import { api } from '../api';
 
 export default function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const navigate = useNavigate();
 
+  const [error, setError] = useState('');
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // TODO: call API
-    navigate('/dashboard');
+    try {
+      const data = await api('/login', {
+        method: 'POST',
+        body: JSON.stringify({ email, password }),
+      });
+      localStorage.setItem('token', data.token);
+      navigate('/dashboard');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Login failed';
+      setError(msg);
+    }
   };
 
   return (
@@ -17,6 +29,7 @@ export default function Login() {
       <div className="bg-white shadow-md rounded px-8 py-6 w-full max-w-md">
         <h2 className="text-2xl font-semibold mb-4 text-center">Login</h2>
         <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+          {error && <p className="text-red-600 text-sm">{error}</p>}
           <input
             className="border rounded p-2"
             placeholder="Email"

--- a/client/src/pages/Signup.tsx
+++ b/client/src/pages/Signup.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
+import { api } from '../api';
 
 export default function Signup() {
   const [username, setUsername] = useState('');
@@ -7,10 +8,20 @@ export default function Signup() {
   const [password, setPassword] = useState('');
   const navigate = useNavigate();
 
+  const [error, setError] = useState('');
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // TODO: call API
-    navigate('/login');
+    try {
+      await api('/signup', {
+        method: 'POST',
+        body: JSON.stringify({ username, email, password }),
+      });
+      navigate('/login');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Signup failed';
+      setError(msg);
+    }
   };
 
   return (
@@ -18,6 +29,7 @@ export default function Signup() {
       <div className="bg-white shadow-md rounded px-8 py-6 w-full max-w-md">
         <h2 className="text-2xl font-semibold mb-4 text-center">Sign Up</h2>
         <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+          {error && <p className="text-red-600 text-sm">{error}</p>}
           <input
             className="border rounded p-2"
             placeholder="Username"


### PR DESCRIPTION
## Summary
- attach auth token in shared API helper and surface request errors
- wire up signup and login forms to backend and show feedback
- log moods, journal entries, and chat messages via API

## Testing
- `cd server && npm test`
- `cd client && npm test` *(fails: Missing script "test")*
- `cd client && npm run lint`
- `cd client && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68957c5835188331af3aef4b9a34ceb9